### PR TITLE
correct name of the main data file

### DIFF
--- a/data/package.json
+++ b/data/package.json
@@ -8,7 +8,7 @@
     "name": "Valérian Galliat",
     "url": "https://val.codejam.info/"
   },
-  "main": "airports",
+  "main": "airports.json",
   "repository": {
     "type": "git",
     "url": "https://github.com/valeriangalliat/fetch-airport-data.git"


### PR DESCRIPTION
To avoid an error `warn: main file for module 'airport-data' does not exist (node_modules/airport-data/airports), assuming index.js` of a builder